### PR TITLE
fixed attempt to decode a generator instead of its elements

### DIFF
--- a/clickhouse_cli/cli.py
+++ b/clickhouse_cli/cli.py
@@ -254,7 +254,7 @@ class CLI:
         self.echo.print()
 
         if stream:
-            print('\n'.join(response.data.decode('utf-8', 'ignore')), end='')
+            print('\n'.join((e.decode('utf-8', 'ignore') for e in response.data)), end='')
         else:
             if response.data != '':
                 print_func = self.echo.pager if self.config.getboolean('main', 'pager') else print


### PR DESCRIPTION
The `cli.Cli.handle_query` method was trying to decode a generator instead of its elements when  a `--query` argument was provided in the command line. The traceback was:
```
Traceback (most recent call last):
  File "cli.py", line 334, in <module>
    run_cli()
  File "/usr/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "cli.py", line 330, in run_cli
    cli.run(query=query, data=sql_input)
  File "cli.py", line 125, in run
    return self.handle_query(query, stream=True)
  File "cli.py", line 258, in handle_query
    print('\n'.join(response.data.decode('utf-8', 'ignore')), end='')
AttributeError: 'generator' object has no attribute 'decode'
```

This PR fixes the problem decoding the elements of the generator using a ~~tuple comprehension~~ generator expression. 