### PR TITLE
support reading clickhouse password from env

### DIFF
--- a/clickhouse_cli/cli.py
+++ b/clickhouse_cli/cli.py
@@ -142,7 +142,7 @@ class CLI:
         self.host = self.host or self.config.get('defaults', 'host') or '127.0.0.1'
         self.port = self.port or self.config.get('defaults', 'port') or 8123
         self.user = self.user or self.config.get('defaults', 'user') or 'default'
-        self.password = self.password or self.config.get('defaults', 'password') or ''
+        self.password = self.password or self.config.get('defaults', 'password') or os.environ.get('CLICKHOUSE_PASSWORD', '')
         self.database = self.database or self.config.get('defaults', 'db') or 'default'
 
         config_settings = dict(self.config.items('settings'))


### PR DESCRIPTION
This allow user to read clickhouse password from the env variable. One
can use it like this to avoid saving password the the configuration file:

```
export CLICKHOUSE_PASSWORD=$(gpg --decrypt my-clickhouse-password.gpg)
clickhouse-cli
```