### PR TITLE
Handle new connection errors

### DIFF
--- a/clickhouse_cli/clickhouse/client.py
+++ b/clickhouse_cli/clickhouse/client.py
@@ -116,7 +116,8 @@ class Client(object):
             )
         except requests.exceptions.ConnectTimeout as e:
             raise TimeoutError(*e.args) from e
-        except requests.exceptions.ConnectionError as e:
+        except (requests.exceptions.ConnectionError,
+            requests.packages.urllib3.exceptions.NewConnectionError) as e:
             raise ConnectionError(*e.args) from e
 
         if response is not None and response.status_code != 200:


### PR DESCRIPTION
Current code fails this way if server is not available:
```
$ clickhouse-cli -h localhost
clickhouse-cli version: 0.2.5.1
Connecting to localhost:8123
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/urllib3/connection.py", line 159, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw)
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/connection.py", line 80, in create_connection
    raise err
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/connection.py", line 70, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 61] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/clickhouse-cli", line 10, in <module>
    sys.exit(run_cli())
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/clickhouse_cli/cli.py", line 527, in run_cli
    cli.run(query, data_input)
  File "/usr/local/lib/python3.7/site-packages/clickhouse_cli/cli.py", line 172, in run
    if not self.connect():
  File "/usr/local/lib/python3.7/site-packages/clickhouse_cli/cli.py", line 99, in connect
    response = self.client.query('SELECT version();', fmt='TabSeparated')
  File "/usr/local/lib/python3.7/site-packages/clickhouse_cli/clickhouse/client.py", line 247, in query
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/clickhouse_cli/clickhouse/client.py", line 115, in _query
    **kwargs
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/requests/adapters.py", line 467, in send
    low_conn.endheaders()
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1224, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 1016, in _send_output
    self.send(msg)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/client.py", line 956, in send
    self.connect()
  File "/usr/local/lib/python3.7/site-packages/urllib3/connection.py", line 181, in connect
    conn = self._new_conn()
  File "/usr/local/lib/python3.7/site-packages/urllib3/connection.py", line 168, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x10dcf1b70>: Failed to establish a new connection: [Errno 61] Connection refused
```

After the change is made
```
$ clickhouse-cli -h localhost
clickhouse-cli version: 0.2.5.1
Connecting to localhost:8123
Error: Failed to connect. (<urllib3.connection.HTTPConnection object at 0x1064a08d0>: Failed to establish a new connection: [Errno 61] Connection refused)
```