### PR TITLE
Fixed broken dependency to prompt-toolkit

### DIFF
--- a/clickhouse_cli/cli.py
+++ b/clickhouse_cli/cli.py
@@ -16,10 +16,10 @@ import click
 import pygments
 import sqlparse
 from pygments.formatters import TerminalFormatter, TerminalTrueColorFormatter
+
+
 from prompt_toolkit import Application, PromptSession
 from prompt_toolkit.lexers import PygmentsLexer
-from prompt_toolkit.eventloop.defaults import use_asyncio_event_loop
-from prompt_toolkit.shortcuts import prompt
 from prompt_toolkit.layout.containers import Window
 from prompt_toolkit.layout.controls import BufferControl
 from prompt_toolkit.layout.layout import Layout
@@ -286,9 +286,6 @@ class CLI:
             layout=layout,
             # buffer=buffer,
         )
-
-        # eventloop = create_eventloop()
-        use_asyncio_event_loop()
 
         #self.cli = CommandLineInterface(application=application, eventloop=eventloop)
         if self.refresh_metadata_on_start:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=6.6
-prompt-toolkit>=2.0
+prompt-toolkit>=3.0
 pygments>=2.1.3
 requests>=2.11.1
 sqlparse>=0.2.2


### PR DESCRIPTION
Fixed code to match prompt-toolkit version 3. Explicitly set version to 3 since that's what's being installed anyway.