### PR TITLE
Print status code and response when "hello" version query fails

### DIFF
--- a/clickhouse_cli/cli.py
+++ b/clickhouse_cli/cli.py
@@ -129,7 +129,9 @@ class CLI:
             return False
 
         if not response.data.endswith('\n'):
-            self.echo.error("Error: Request failed: `SELECT version();` query failed.")
+            self.echo.error("Error: Request failed: `SELECT version();` query failed with status code: {}.".format(response.status_code))
+            self.echo.error(response.data)
+
             return False
 
         version = response.data.strip().split('.')

--- a/clickhouse_cli/clickhouse/client.py
+++ b/clickhouse_cli/clickhouse/client.py
@@ -36,9 +36,11 @@ class Response(object):
         self.stream = stream
         self.time_elapsed = None
         self.rows = None
+        self.status_code = None
 
         if isinstance(response, requests.Response):
             self.time_elapsed = response.elapsed.total_seconds()
+            self.status_code = response.status_code
 
             if stream:
                 self.data = response.iter_lines()


### PR DESCRIPTION
This makes the actually useful instead of just saying "whoops".