### PR TITLE
Add the insecure option to allow skip the server certificate verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Python 3.4+ is required.
       -f, --format TEXT        Data format for the interactive mode
       -F, --format-stdin TEXT  Data format for stdin/file queries
       -m, --multiline          Enable multiline shell
+      -k, --insecure           Allow insecure server connections when using SSL
       --stacktrace             Print stacktraces received from the server.
       --version                Show the version and exit.
       --help                   Show this message and exit.
@@ -62,6 +63,8 @@ Python 3.4+ is required.
 
 
     [main]
+    # Allow insecure server connections when using SSL
+    insecure = False
     # Disable multiline mode by default
     multiline = False
 

--- a/clickhouse_cli/cli.py
+++ b/clickhouse_cli/cli.py
@@ -59,7 +59,7 @@ class CLI:
 
     def __init__(self, host, port, user, password, database,
                  settings, format, format_stdin, multiline, stacktrace,
-                 vi_mode, cookie):
+                 vi_mode, cookie, insecure):
         self.config = None
 
         self.host = host
@@ -75,6 +75,7 @@ class CLI:
         self.stacktrace = stacktrace
         self.vi_mode = vi_mode
         self.server_version = None
+        self.insecure = insecure
 
         self.query_ids = []
         self.client = None
@@ -101,6 +102,7 @@ class CLI:
             self.conn_timeout,
             self.conn_timeout_retry,
             self.conn_timeout_retry_delay,
+            not self.insecure,
         )
 
         self.echo.print("Connecting to {host}:{port}".format(
@@ -147,6 +149,7 @@ class CLI:
     def load_config(self):
         self.config = read_config()
 
+        self.insecure = self.insecure or self.config.getboolean('main', 'insecure')
         self.multiline = self.multiline or self.config.getboolean('main', 'multiline')
         self.vi_mode = self.vi_mode or self.config.getboolean('main', 'vi_mode')
         self.format = self.format or self.config.get('main', 'format')
@@ -544,6 +547,7 @@ class CLI:
 @click.option('--settings', '-s', help="Query string to be sent with every query")
 @click.option('--cookie', '-c', help="Cookie header to be sent with every query")
 @click.option('--query', '-q', help="Query to execute")
+@click.option('--insecure', '-k', is_flag=True, help="Allow insecure server connections when using SSL")
 @click.option('--format', '-f', help="Data format for the interactive mode")
 @click.option('--format-stdin', '-F', help="Data format for stdin/file queries")
 @click.option('--multiline', '-m', is_flag=True, help="Enable multiline shell")
@@ -552,7 +556,7 @@ class CLI:
 @click.option('--version', is_flag=True, help="Show the version and exit.")
 @click.argument('files', nargs=-1, type=click.File('rb'))
 def run_cli(host, port, user, password, arg_password, database, settings, query, format,
-            format_stdin, multiline, stacktrace, vi_mode, cookie, version, files):
+            format_stdin, multiline, stacktrace, vi_mode, cookie, version, files, insecure):
     """
     A third-party client for the ClickHouse DBMS.
     """
@@ -577,7 +581,7 @@ def run_cli(host, port, user, password, arg_password, database, settings, query,
 
     # TODO: Rename the CLI's instance into something more feasible
     cli = CLI(
-        host, port, user, password, database, settings, format, format_stdin, multiline, stacktrace, vi_mode, cookie
+        host, port, user, password, database, settings, format, format_stdin, multiline, stacktrace, vi_mode, cookie, insecure
     )
     cli.run(query, data_input)
 

--- a/clickhouse_cli/clickhouse-cli.rc.sample
+++ b/clickhouse_cli/clickhouse-cli.rc.sample
@@ -11,6 +11,8 @@ cookie =
 # It's not secure to store the password here in plain text.
 
 [main]
+# Allow insecure server connections when using SSL
+insecure = False
 # Disable multiline mode by default
 multiline = False
 

--- a/clickhouse_cli/clickhouse/client.py
+++ b/clickhouse_cli/clickhouse/client.py
@@ -68,7 +68,7 @@ class Response(object):
 class Client(object):
 
     def __init__(self, url, user, password, database, cookie, stacktrace=False, timeout=10.0,
-                 timeout_retry=0, timeout_retry_delay=0.0):
+                 timeout_retry=0, timeout_retry_delay=0.0, verify=True):
         self.url = url
         self.user = user
         self.password = password or ''
@@ -79,6 +79,7 @@ class Client(object):
         self.stacktrace = stacktrace
         self.timeout = timeout
         self.session = requests.Session()
+        self.verify = verify
 
         retries = Retry(
             connect=timeout_retry,
@@ -118,6 +119,7 @@ class Client(object):
                 stream=stream,
                 headers=headers,
                 timeout=(self.timeout, None),
+                verify=self.verify,
                 **kwargs
             )
         except requests.exceptions.ConnectTimeout as e:


### PR DESCRIPTION
Currently, `clickhouse-cli` got the below error when the server SSL certificates is self-signed:

```shell
Error: Failed to connect. ([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997))
```

For the most ClickHouse services will use self-signed certificates, so it'd be more convenient if we can skip the verify when testing. 